### PR TITLE
Potential fix for code scanning alert no. 2: URL redirection from remote source

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,6 +1,7 @@
 import os
 import json
 from flask import Flask, request, render_template, redirect, url_for, session, g
+from urllib.parse import urlparse
 from datetime import datetime
 REQUIRED_PIN = os.environ.get('FLOORBALL_PIN', '1717')
 
@@ -199,10 +200,14 @@ def set_language_route():
     if lang not in LANGUAGES:
         lang = default
     session['lang'] = lang
-    # Redirect back to previous page or home
+    # Redirect back to previous page or home safely
     ref = request.referrer or url_for('index')
-    return redirect(ref)
-
+    # Remove backslashes which some browsers accept
+    safe_ref = ref.replace('\\', '')
+    parsed = urlparse(safe_ref)
+    if not parsed.netloc and not parsed.scheme:
+        return redirect(safe_ref)
+    return redirect(url_for('index'))
 
 PERIODS = ["1", "2", "3", "OT"]
 


### PR DESCRIPTION
Potential fix for [https://github.com/dennyschwender/FloorballStatsTracker/security/code-scanning/2](https://github.com/dennyschwender/FloorballStatsTracker/security/code-scanning/2)

To fix the open redirect vulnerability, the code should check that the redirect target (`ref`) is a safe, local URL. Since the referring page can be an external or even dangerous site, the redirect should only proceed if the target is a relative URL (i.e., does not contain a scheme or hostname), or if present in an explicit whitelist (not shown here). We should use `urlparse` from the standard library to analyze the `ref` value, remove any dangerous slashes, and ensure both `scheme` and `netloc` are empty before redirecting to it. Otherwise, safely redirect to the home page using `url_for('index')`.

Modify the definition of `set_language_route` (lines 194-205) so that, before redirecting to `ref`, you check its safety with these validations. Add an import for `urlparse` if not present, and apply the fix only in the relevant lines.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
