### PR TITLE
fix(ui): decouple undo toast state and extend duration to 8s

### DIFF
--- a/templates/game_details.html
+++ b/templates/game_details.html
@@ -599,10 +599,13 @@
     };
 
     // ── Undo toast ────────────────────────────────────────────────────────────
+    // Uses a separate element ref so regular showToast calls don't kill the undo toast.
+    var _undoToastEl = null;
     var _undoTimer = null;
     function showUndoToast(actionName) {
-        if (_toastEl) { _toastEl.remove(); _toastEl = null; }
+        if (_undoToastEl) { _undoToastEl.remove(); _undoToastEl = null; }
         if (_undoTimer) { clearTimeout(_undoTimer); _undoTimer = null; }
+        if (_toastEl) { _toastEl.remove(); _toastEl = null; }
 
         var wrapper = document.createElement('div');
         wrapper.className = 'alert alert-secondary py-2 px-3 mb-0 d-flex align-items-center gap-3';
@@ -625,10 +628,10 @@
         wrapper.appendChild(closeBtn);
 
         document.body.appendChild(wrapper);
-        _toastEl = wrapper;
+        _undoToastEl = wrapper;
 
         undoBtn.addEventListener('click', function () {
-            wrapper.remove(); _toastEl = null;
+            wrapper.remove(); _undoToastEl = null;
             if (_undoTimer) { clearTimeout(_undoTimer); _undoTimer = null; }
             fetch('/undo/' + GAME_ID, {
                 headers: {'X-Requested-With': 'XMLHttpRequest'},
@@ -646,14 +649,14 @@
         });
 
         closeBtn.addEventListener('click', function () {
-            wrapper.remove(); _toastEl = null;
+            wrapper.remove(); _undoToastEl = null;
             if (_undoTimer) { clearTimeout(_undoTimer); _undoTimer = null; }
         });
 
         _undoTimer = setTimeout(function () {
-            if (_toastEl === wrapper) { wrapper.remove(); _toastEl = null; }
+            if (_undoToastEl === wrapper) { wrapper.remove(); _undoToastEl = null; }
             _undoTimer = null;
-        }, 5000);
+        }, 8000);
     }
 
     // ── Core action fetch ─────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Undo toast now uses `_undoToastEl` (separate from `_toastEl`) so `showToast` calls (e.g. offline sync messages) no longer silently kill the undo toast
- Auto-dismiss extended from 5 s → 8 s for live game tracking use

## Test plan
- [ ] Record a stat action in edit mode — undo toast appears at bottom-right
- [ ] Trigger an offline sync message while undo toast is visible — undo toast stays
- [ ] Wait 8 s — undo toast auto-dismisses
- [ ] Click Undo button — stat reverts correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)